### PR TITLE
Separating makeup days

### DIFF
--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -285,11 +285,29 @@ namespace CV19INeedHelp.Gateways.V1
                 .Where(x => x.RecordStatus.ToUpper() == "MASTER"
                             && x.IsDuplicate.ToUpper() == "FALSE"
                             && x.OngoingFoodNeed == true
-                            && (x.LastConfirmedFoodDelivery > helper.GetNextWorkingDay().AddDays(-7) && x.LastConfirmedFoodDelivery <= helper.GetNextWorkingDay().AddDays(-5)))
+                            && (x.LastConfirmedFoodDelivery > helper.GetNextWorkingDay().AddDays(-7) && x.LastConfirmedFoodDelivery <= helper.GetNextWorkingDay().AddDays(-6)))
                 .OrderBy(x => x.Id)
                 .Take(remainingCapacity).ToList();
             LambdaLogger.Log($"Final priority returned {response.Count + output.Count} records against a limit of {limit}.");
             response.AddRange(output);
+            
+            if (response.Count >= limit)
+            {
+                LambdaLogger.Log($"Second priority returned {response.Count + output.Count} records against a limit of {limit}.  Capacity reached");
+                return response.OrderBy(x => x.Id).ToList();
+            }
+            remainingCapacity = limit - response.Count;
+            LambdaLogger.Log($"Second priority returned {response.Count + output.Count} records against a limit of {limit}.  Capacity not reached. Adding next priority.");
+            output = _dbContext.ResidentSupportAnnex
+                .Where(x => x.RecordStatus.ToUpper() == "MASTER"
+                            && x.IsDuplicate.ToUpper() == "FALSE"
+                            && x.OngoingFoodNeed == true
+                            && (x.LastConfirmedFoodDelivery > helper.GetNextWorkingDay().AddDays(-6) && x.LastConfirmedFoodDelivery <= helper.GetNextWorkingDay().AddDays(-5)))
+                .OrderBy(x => x.Id)
+                .Take(remainingCapacity).ToList();
+            LambdaLogger.Log($"Final priority returned {response.Count + output.Count} records against a limit of {limit}.");
+            response.AddRange(output);
+            
             return response.OrderBy(x => x.Id).ToList();
         }
     }


### PR DESCRIPTION
To ensure capacity is built from oldest day first.