### PR TITLE
Refactor test files to use common database setup code

### DIFF
--- a/cv-19-i-need-help-test/EndToEndTests/V1/GetHelpRequestTest.cs
+++ b/cv-19-i-need-help-test/EndToEndTests/V1/GetHelpRequestTest.cs
@@ -1,14 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Lambda.APIGatewayEvents;
 using AutoFixture;
-using CV19INeedHelp;
 using CV19INeedHelp.Boundary.V1;
 using CV19INeedHelp.Boundary.V1.Responses;
-using CV19INeedHelp.Data.V1;
 using CV19INeedHelp.Helpers.V1;
 using CV19INeedHelp.Models.V1;
+using CV19INeedHelpTest.EndToEndTests.V2;
+using CV19INeedHelpTest.TestHelpers;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -16,40 +15,17 @@ using NUnit.Framework;
 namespace CV19INeedHelpTest.EndToEndTests.V1
 {
     [TestFixture]
-    public class GetHelpRequestTest
+    public class GetHelpRequestTest : DatabaseTests
     {
-        private string _currentConnStr;
         private Handler _handler;
         private Fixture _fixture;
-        private Cv19SupportDbContext _dbContext;
 
         [SetUp]
         public void SetUp()
         {
-            _currentConnStr = Environment.GetEnvironmentVariable("CV_19_DB_CONNECTION");
-            const string connectionString =
-                "Host=localhost;Database=i-need-help-test;Username=postgres;Password=mypassword";
-            _dbContext = new Cv19SupportDbContext(_currentConnStr ?? connectionString);
-            if (_currentConnStr == null) Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", connectionString);
             _fixture = new Fixture();
             _handler = new Handler();
-
-            AssertionOptions.AssertEquivalencyUsing(options =>
-            {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTime>();
-                options.Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation))
-                    .WhenTypeIs<DateTimeOffset>();
-                return options;
-            });
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _currentConnStr);
-            var addedEntities = _dbContext.ResidentSupportAnnex;
-            _dbContext.ResidentSupportAnnex.RemoveRange(addedEntities);
-            _dbContext.SaveChanges();
+            CustomizeAssertions.ApproximationDateTime();
         }
 
         [Test]
@@ -57,8 +33,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V1
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
             helpRequests.First().Id = 1;
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var request = new APIGatewayProxyRequest
             {

--- a/cv-19-i-need-help-test/EndToEndTests/V1/GetHelpRequestsTest.cs
+++ b/cv-19-i-need-help-test/EndToEndTests/V1/GetHelpRequestsTest.cs
@@ -1,13 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Lambda.APIGatewayEvents;
 using AutoFixture;
 using CV19INeedHelp.Boundary.V1;
 using CV19INeedHelp.Boundary.V1.Responses;
-using CV19INeedHelp.Data.V1;
 using CV19INeedHelp.Helpers.V1;
 using CV19INeedHelp.Models.V1;
+using CV19INeedHelpTest.EndToEndTests.V2;
+using CV19INeedHelpTest.TestHelpers;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -15,46 +15,26 @@ using NUnit.Framework;
 namespace CV19INeedHelpTest.EndToEndTests.V1
 {
     [TestFixture]
-    public class GetHelpRequestsTest
+    public class GetHelpRequestsTest : DatabaseTests
     {
-        private string _currentConnStr;
         private Handler _handler;
         private Fixture _fixture;
-        private Cv19SupportDbContext _dbContext;
 
         [SetUp]
         public void SetUp()
         {
-            _currentConnStr = Environment.GetEnvironmentVariable("CV_19_DB_CONNECTION");
-            const string connectionString = "Host=localhost;Database=i-need-help-test;Username=postgres;Password=mypassword";
-            _dbContext = new Cv19SupportDbContext(_currentConnStr ?? connectionString);
-            if (_currentConnStr == null) Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", connectionString);
             _fixture = new Fixture();
             _handler = new Handler();
 
-            AssertionOptions.AssertEquivalencyUsing(options =>
-            {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTime>();
-                options.Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTimeOffset>();
-                return options;
-            });
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _currentConnStr);
-            var addedEntities = _dbContext.ResidentSupportAnnex;
-            _dbContext.ResidentSupportAnnex.RemoveRange(addedEntities);
-            _dbContext.SaveChanges();
+            CustomizeAssertions.ApproximationDateTime();
         }
 
         [Test]
         public void WithNoQueryParameters_ReturnsEverythingInResidentSupportAnnex()
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var response = _handler.GetHelpRequests(new APIGatewayProxyRequest(), null);
 
@@ -72,8 +52,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V1
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
             helpRequests.First().Uprn = "to-search-for";
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var request = new APIGatewayProxyRequest
             {
@@ -97,8 +77,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V1
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
             helpRequests.Last().Postcode = "return-me";
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var request = new APIGatewayProxyRequest
             {

--- a/cv-19-i-need-help-test/EndToEndTests/V2/DatabaseTests.cs
+++ b/cv-19-i-need-help-test/EndToEndTests/V2/DatabaseTests.cs
@@ -1,0 +1,36 @@
+using System;
+using CV19INeedHelp.Data.V1;
+using NUnit.Framework;
+
+namespace CV19INeedHelpTest.EndToEndTests.V2
+{
+    public class DatabaseTests
+    {
+        private string _currentConnStr;
+        protected Cv19SupportDbContext DbContext;
+
+        [SetUp]
+        public void SetDbContext()
+        {
+            _currentConnStr = Environment.GetEnvironmentVariable("CV_19_DB_CONNECTION");
+            const string connectionString = "Host=localhost;Database=i-need-help-test;Username=postgres;Password=mypassword";
+            DbContext = new Cv19SupportDbContext(_currentConnStr ?? connectionString);
+            ClearResidentSupportAnnexTable();
+            if (_currentConnStr == null) Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", connectionString);
+        }
+
+        [TearDown]
+        public void ResetDb()
+        {
+            Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _currentConnStr);
+            ClearResidentSupportAnnexTable();
+        }
+
+        private void ClearResidentSupportAnnexTable()
+        {
+            var addedEntities = DbContext.ResidentSupportAnnex;
+            DbContext.ResidentSupportAnnex.RemoveRange(addedEntities);
+            DbContext.SaveChanges();
+        }
+    }
+}

--- a/cv-19-i-need-help-test/EndToEndTests/V2/GetHelpRequestsTest.cs
+++ b/cv-19-i-need-help-test/EndToEndTests/V2/GetHelpRequestsTest.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Lambda.APIGatewayEvents;
 using AutoFixture;
 using CV19INeedHelp.Boundary.V2;
 using CV19INeedHelp.Boundary.V2.Responses;
-using CV19INeedHelp.Data.V1;
 using CV19INeedHelp.Helpers.V2;
 using CV19INeedHelp.Models.V1;
 using CV19INeedHelpTest.TestHelpers;
@@ -16,50 +14,26 @@ using NUnit.Framework;
 namespace CV19INeedHelpTest.EndToEndTests.V2
 {
     [TestFixture]
-    public class GetHelpRequestsTest
+    public class GetHelpRequestsTest : DatabaseTests
     {
-        private string _currentConnStr;
         private Handler _handler;
         private Fixture _fixture;
-        private Cv19SupportDbContext _dbContext;
 
         [SetUp]
         public void SetUp()
         {
-            _currentConnStr = Environment.GetEnvironmentVariable("CV_19_DB_CONNECTION");
-            const string connectionString = "Host=localhost;Database=i-need-help-test;Username=postgres;Password=mypassword";
-            _dbContext = new Cv19SupportDbContext(_currentConnStr ?? connectionString);
-            var addedEntities = _dbContext.ResidentSupportAnnex;
-            _dbContext.ResidentSupportAnnex.RemoveRange(addedEntities);
-            _dbContext.SaveChanges();
-            if (_currentConnStr == null) Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", connectionString);
             _fixture = new Fixture();
             CustomizeFixture.V2ResidentResponseParsable(_fixture);
             _handler = new Handler();
-
-            AssertionOptions.AssertEquivalencyUsing(options =>
-            {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTime>();
-                options.Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTimeOffset>();
-                return options;
-            });
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _currentConnStr);
-            var addedEntities = _dbContext.ResidentSupportAnnex;
-            _dbContext.ResidentSupportAnnex.RemoveRange(addedEntities);
-            _dbContext.SaveChanges();
+            CustomizeAssertions.ApproximationDateTime();
         }
 
         [Test]
         public void WithNoQueryParameters_ReturnsEverythingInResidentSupportAnnex()
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var response = _handler.GetHelpRequests(new APIGatewayProxyRequest(), null);
 
@@ -79,8 +53,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V2
             {
                 Id = 1,
             };
-            _dbContext.ResidentSupportAnnex.Add(helpRequest);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.Add(helpRequest);
+            DbContext.SaveChanges();
             var response = _handler.GetHelpRequests(new APIGatewayProxyRequest(), null);
             response.StatusCode.Should().Be(200);
             response.Body.Should().BeEquivalentTo(@"{
@@ -99,8 +73,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V2
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
             helpRequests.First().Uprn = "to-search-for";
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var request = new APIGatewayProxyRequest
             {
@@ -124,8 +98,8 @@ namespace CV19INeedHelpTest.EndToEndTests.V2
         {
             var helpRequests = _fixture.CreateMany<ResidentSupportAnnex>().ToList();
             helpRequests.Last().Postcode = "return-me";
-            _dbContext.ResidentSupportAnnex.AddRange(helpRequests);
-            _dbContext.SaveChanges();
+            DbContext.ResidentSupportAnnex.AddRange(helpRequests);
+            DbContext.SaveChanges();
 
             var request = new APIGatewayProxyRequest
             {

--- a/cv-19-i-need-help-test/TestHelpers/CustomizeAssertions.cs
+++ b/cv-19-i-need-help-test/TestHelpers/CustomizeAssertions.cs
@@ -1,0 +1,18 @@
+using System;
+using FluentAssertions;
+
+namespace CV19INeedHelpTest.TestHelpers
+{
+    public static class CustomizeAssertions
+    {
+        public static void ApproximationDateTime()
+        {
+            AssertionOptions.AssertEquivalencyUsing(options =>
+            {
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTime>();
+                options.Using<DateTimeOffset>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation)).WhenTypeIs<DateTimeOffset>();
+                return options;
+            });
+        }
+    }
+}


### PR DESCRIPTION
Moved setup and teardown for the database into a new class that can be inherited by tests which use the database.

Also moved config for making date time assertions approximate into a test helper class as it's used on a few occasions