### PR TITLE
Deliveries regeneration

### DIFF
--- a/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
+++ b/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
@@ -40,7 +40,7 @@ namespace CV19INeedHelpTest.Gateways.V1
         }
 
         [Test]
-        public void WhenCreatingADeliveryBatchReturnAListOfDeliveriesMeetingRequiredCriteria()
+        public void WhenCreatingADeliveryScheduleReturnAListOfDeliveriesMeetingRequiredCriteria()
         {
             var annexRecord = _fixture.Create<ResidentSupportAnnex>();
             //annex record should not have a confirmed delivery

--- a/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
+++ b/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using CV19INeedHelp.Data.V1;
 using CV19INeedHelp.Gateways.V1;
 using CV19INeedHelp.Models.V1;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 
@@ -32,17 +35,48 @@ namespace CV19INeedHelpTest.Gateways.V1
         {
             Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _connectionString);
             ClearResidentSupportAnnexTable();
+            ClearDeliveryBatchTable();
+            ClearDeliveryReportDataTable();
         }
 
-        public void WhenCreatingADeliveryBatchReturnAValidObject()
+        [Test]
+        public void WhenCreatingADeliveryBatchReturnAListOfDeliveriesMeetingRequiredCriteria()
         {
-            
+            var annexRecord = _fixture.Create<ResidentSupportAnnex>();
+            //annex record should not have a confirmed delivery
+            annexRecord.LastConfirmedFoodDelivery = null;
+            //annex record should have an ongoing food need of true
+            annexRecord.OngoingFoodNeed = true;
+            InsertIntoResidentSupportAnnexTable(annexRecord);
+            var response = _classUnderTest.CreateDeliverySchedule(10, "test");
+            response.Count.Should().Be(1);
+            response.First().AnnexId.Should().Be(annexRecord.Id);
         }
         
         private void ClearResidentSupportAnnexTable()
         {
             var addedEntities = _context.ResidentSupportAnnex;
             _context.ResidentSupportAnnex.RemoveRange(addedEntities);
+            _context.SaveChanges();
+        }
+
+        private void ClearDeliveryBatchTable()
+        {
+            var addedEntities = _context.DeliveryBatch;
+            _context.DeliveryBatch.RemoveRange(addedEntities);
+            _context.SaveChanges();
+        }
+
+        private void ClearDeliveryReportDataTable()
+        {
+            var addedEntities = _context.DeliveryReportData;
+            _context.DeliveryReportData.RemoveRange(addedEntities);
+            _context.SaveChanges();
+        }
+
+        private void InsertIntoResidentSupportAnnexTable(ResidentSupportAnnex request)
+        {
+            _context.ResidentSupportAnnex.Add(request);
             _context.SaveChanges();
         }
     }

--- a/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
+++ b/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
@@ -1,4 +1,5 @@
 using System;
+using AutoFixture;
 using CV19INeedHelp.Data.V1;
 using CV19INeedHelp.Gateways.V1;
 using CV19INeedHelp.Models.V1;
@@ -10,24 +11,39 @@ namespace CV19INeedHelpTest.Gateways.V1
     [TestFixture]
     public class INeedHelpGatewayTest
     {
-        [TestCase]
-        public void InsertMethodShouldNotBeCalledWithoutParameter()
+        private INeedHelpGateway _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+        private Cv19SupportDbContext _context;
+        private string _connectionString;
+        
+        [SetUp]
+        public void SetUp()
         {
-//            string connectionString = string.Empty;
-//            var data = new OrganisationsNeedingVolunteers() ;
-//            IOrganisationVolunteerGateway classUnderTest = new OrganisationVolunteerGateway(connectionString);
-//            var resp = classUnderTest.Insert(data);
-//            Assert.AreEqual(1,resp);
+            _connectionString = Environment.GetEnvironmentVariable("CV_19_DB_CONNECTION");
+            const string connectionString = "Host=localhost;Database=i-need-help-test;Username=postgres;Password=mypassword";
+            _context= new Cv19SupportDbContext(_connectionString ?? connectionString);
+            ClearResidentSupportAnnexTable();
+            if (_connectionString == null) Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", connectionString);
+            _classUnderTest = new INeedHelpGateway(_context);
         }
         
-        public void WhenCreatingAResidentRequestGivenValidParametersReturnAValidObject()
+        [TearDown]
+        public void ResetDb()
         {
-            //Arrange
-            string _connectionString = "blah";
-            var fakeDbContext = new Mock<Cv19SupportDbContext>(_connectionString);
+            Environment.SetEnvironmentVariable("CV_19_DB_CONNECTION", _connectionString);
+            ClearResidentSupportAnnexTable();
+        }
 
-            IINeedHelpGateway classUnderTest = new INeedHelpGateway(fakeDbContext.Object);
-
+        public void WhenCreatingADeliveryBatchReturnAValidObject()
+        {
+            
+        }
+        
+        private void ClearResidentSupportAnnexTable()
+        {
+            var addedEntities = _context.ResidentSupportAnnex;
+            _context.ResidentSupportAnnex.RemoveRange(addedEntities);
+            _context.SaveChanges();
         }
     }
 }

--- a/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
+++ b/cv-19-i-need-help-test/Gateways/V1/INeedHelpGatewayTest.cs
@@ -52,7 +52,45 @@ namespace CV19INeedHelpTest.Gateways.V1
             response.Count.Should().Be(1);
             response.First().AnnexId.Should().Be(annexRecord.Id);
         }
+
+        [Test]
+        public void WhenSuppliedADateReturnsTheFirstRecordWithThatDate()
+        {
+            var batch = _fixture.Create<DeliveryBatch>();
+            batch.DeliveryDate = DateTime.Now.AddDays(1);
+            InsertIntoDeliveryBatchTable(batch);
+            var response = _classUnderTest.FindExistingBatchForDate(DateTime.Now.AddDays(1));
+            response.Should().BeEquivalentTo(batch);
+        }
         
+        [Test]
+        public void WhenSuppliedADateNotRecordedReturnsNull()
+        {
+            var batch = _fixture.Create<DeliveryBatch>();
+            batch.DeliveryDate = DateTime.Now.AddDays(1);
+            InsertIntoDeliveryBatchTable(batch);
+            var response = _classUnderTest.FindExistingBatchForDate(DateTime.Now);
+            response.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenIdOfExistingBatchRecordIsSuppliedReturnsWithBatchRecord()
+        {
+            var batch = _fixture.Create<DeliveryBatch>();
+            InsertIntoDeliveryBatchTable(batch);
+            var response = _classUnderTest.GetBatchById(batch.Id);
+            response.Should().BeEquivalentTo(batch);
+        }
+        
+        [Test]
+        public void WhenIdIsSuppliedThatDoesNotExistReturnsWithNull()
+        {
+            var batch = _fixture.Create<DeliveryBatch>();
+            InsertIntoDeliveryBatchTable(batch);
+            var response = _classUnderTest.GetBatchById(batch.Id+10);
+            response.Should().BeNull();
+        }
+
         private void ClearResidentSupportAnnexTable()
         {
             var addedEntities = _context.ResidentSupportAnnex;
@@ -77,6 +115,12 @@ namespace CV19INeedHelpTest.Gateways.V1
         private void InsertIntoResidentSupportAnnexTable(ResidentSupportAnnex request)
         {
             _context.ResidentSupportAnnex.Add(request);
+            _context.SaveChanges();
+        }
+        
+        private void InsertIntoDeliveryBatchTable(DeliveryBatch batchRecord)
+        {
+            _context.DeliveryBatch.Add(batchRecord);
             _context.SaveChanges();
         }
     }

--- a/cv-19-i-need-help.sln.DotSettings.user
+++ b/cv-19-i-need-help.sln.DotSettings.user
@@ -1,5 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Int64 x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/AutoNamingCompletedVersion/@EntryValue">2</s:Int64>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=ffbff679_002D952e_002D49c6_002D8df4_002D0491f0acd704/@EntryIndexedValue">&lt;SessionState ContinuousTestingIsOn="False" ContinuousTestingMode="0" FrameworkVersion="{x:Null}" IsLocked="False" Name="All tests from Solution" PlatformMonoPreference="{x:Null}" PlatformType="{x:Null}" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"&gt;
-  &lt;Solution /&gt;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/cv-19-i-need-help/Boundary/V1/Handler.cs
+++ b/cv-19-i-need-help/Boundary/V1/Handler.cs
@@ -325,10 +325,12 @@ namespace CV19INeedHelp.Boundary.V1
             catch(Exception e)
             {
                 LambdaLogger.Log("Error: " + e.Message);
-                var response = new Response();
-                response.isBase64Encoded = true;
-                response.statusCode = "500";
-                response.body = "Error processing request: " + ". Error Details: " + e.Message + e.StackTrace;
+                var response = new Response
+                {
+                    isBase64Encoded = true,
+                    statusCode = "500",
+                    body = "Error processing request: " + ". Error Details: " + e.Message + e.StackTrace
+                };
                 return response;
             }
         }
@@ -338,11 +340,23 @@ namespace CV19INeedHelp.Boundary.V1
             var deleteBatchGateway = new INeedHelpGateway(new Cv19SupportDbContext(_connectionString));
             var driveHelper = new DriveHelper();
             var deleteBatchObject = new DeliveryScheduleUseCase(deleteBatchGateway, driveHelper);
-            var request_params = request.PathParameters;
-            var batch_id = Int32.Parse(request_params["id"]);
+            var requestParams = request.PathParameters;
+            int batchId;
             try
             {
-                deleteBatchObject.DeleteDeliveryBatch(batch_id);
+                batchId = Int32.Parse(requestParams["id"]);
+            }
+            catch
+            {
+                var response = new Response();
+                response.isBase64Encoded = true;
+                LambdaLogger.Log("No batch id specified.");
+                response.statusCode = "400";
+                return response;
+            }
+            try
+            {
+                deleteBatchObject.DeleteDeliveryBatch(batchId);
                 var response = new Response();
                 response.isBase64Encoded = true;
                 LambdaLogger.Log("Batch successfully deleted.");

--- a/cv-19-i-need-help/Boundary/V1/Handler.cs
+++ b/cv-19-i-need-help/Boundary/V1/Handler.cs
@@ -336,7 +336,8 @@ namespace CV19INeedHelp.Boundary.V1
         public Response DeleteDeliveryBatch(APIGatewayProxyRequest request, ILambdaContext context)
         {
             var deleteBatchGateway = new INeedHelpGateway(new Cv19SupportDbContext(_connectionString));
-            var deleteBatchObject = new DeliveryScheduleUseCase(deleteBatchGateway, null);
+            var driveHelper = new DriveHelper();
+            var deleteBatchObject = new DeliveryScheduleUseCase(deleteBatchGateway, driveHelper);
             var request_params = request.PathParameters;
             var batch_id = Int32.Parse(request_params["id"]);
             try

--- a/cv-19-i-need-help/Boundary/V1/Handler.cs
+++ b/cv-19-i-need-help/Boundary/V1/Handler.cs
@@ -299,6 +299,65 @@ namespace CV19INeedHelp.Boundary.V1
                 return response;
             }
         }
+
+        public Response GetDeliveryBatch(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var getBatchGateway = new INeedHelpGateway(new Cv19SupportDbContext(_connectionString));
+            var getBatchObject = new DeliveryScheduleUseCase(getBatchGateway, null);
+            try
+            {
+                var resp = getBatchObject.GetDeliveryBatch();
+                var response = new Response();
+                response.isBase64Encoded = true;
+                if (resp == null)
+                {
+                    LambdaLogger.Log("No batch available for date specified.");
+                    response.statusCode = "404";
+                }
+                else
+                {
+                    LambdaLogger.Log("Batch retrieval success: " + JsonConvert.SerializeObject(resp));
+                    response.statusCode = "200";
+                    response.body = JsonConvert.SerializeObject(resp);
+                }
+                return response;
+            }
+            catch(Exception e)
+            {
+                LambdaLogger.Log("Error: " + e.Message);
+                var response = new Response();
+                response.isBase64Encoded = true;
+                response.statusCode = "500";
+                response.body = "Error processing request: " + ". Error Details: " + e.Message + e.StackTrace;
+                return response;
+            }
+        }
+
+        public Response DeleteDeliveryBatch(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var deleteBatchGateway = new INeedHelpGateway(new Cv19SupportDbContext(_connectionString));
+            var deleteBatchObject = new DeliveryScheduleUseCase(deleteBatchGateway, null);
+            var request_params = request.PathParameters;
+            var batch_id = Int32.Parse(request_params["id"]);
+            try
+            {
+                deleteBatchObject.DeleteDeliveryBatch(batch_id);
+                var response = new Response();
+                response.isBase64Encoded = true;
+                LambdaLogger.Log("Batch successfully deleted.");
+                response.statusCode = "200";
+                return response;
+            }
+            catch(Exception e)
+            {
+                LambdaLogger.Log("Error: " + e.Message);
+                var response = new Response();
+                response.isBase64Encoded = true;
+                response.statusCode = "500";
+                response.body = "Error processing request: " + ". Error Details: " + e.Message + e.StackTrace;
+                return response;
+            }
+        }
     }
 
     public class Response

--- a/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
@@ -20,7 +20,6 @@ namespace CV19INeedHelp.Gateways.V1
         void UpdateAnnexWithDeliveryDates(List<DeliveryReportItem> data);
         DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay);
         void DeleteBatch(int id);
-        void RevertAnnexDeliveryDates(List<DeliveryReportItem> data);
         DeliveryBatch GetBatchById(int id);
     }
 }

--- a/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CV19INeedHelp.Models;
 using CV19INeedHelp.Models.V1;
@@ -17,5 +18,6 @@ namespace CV19INeedHelp.Gateways.V1
         List<DeliveryReportItem> CreateDeliverySchedule(int limit, string spreadsheet);
         List<ResidentSupportAnnex> CreateTemporaryDeliveryData(int limit);
         void UpdateAnnexWithDeliveryDates(List<DeliveryReportItem> data);
+        DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay);
     }
 }

--- a/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
@@ -19,5 +19,7 @@ namespace CV19INeedHelp.Gateways.V1
         List<ResidentSupportAnnex> CreateTemporaryDeliveryData(int limit);
         void UpdateAnnexWithDeliveryDates(List<DeliveryReportItem> data);
         DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay);
+        void DeleteBatch(int id);
+        void RevertAnnexDeliveryDates(List<DeliveryReportItem> data);
     }
 }

--- a/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
@@ -21,5 +21,6 @@ namespace CV19INeedHelp.Gateways.V1
         DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay);
         void DeleteBatch(int id);
         void RevertAnnexDeliveryDates(List<DeliveryReportItem> data);
+        DeliveryBatch GetBatchById(int id);
     }
 }

--- a/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/IINeedHelpGateway.cs
@@ -16,5 +16,6 @@ namespace CV19INeedHelp.Gateways.V1
         List<ResidentSupportAnnex> GetRequestExceptions();
         List<DeliveryReportItem> CreateDeliverySchedule(int limit, string spreadsheet);
         List<ResidentSupportAnnex> CreateTemporaryDeliveryData(int limit);
+        void UpdateAnnexWithDeliveryDates(List<DeliveryReportItem> data);
     }
 }

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -259,6 +259,12 @@ namespace CV19INeedHelp.Gateways.V1
             _dbContext.SaveChanges();
         }
 
+        public DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay)
+        {
+            var batchSearch = _dbContext.DeliveryBatch.FirstOrDefault(x => x.DeliveryDate == deliveryDay);
+            return batchSearch;
+        }
+
         private List<ResidentSupportAnnex> GetData(int limit)
         {
             var helper = new UtilityHelper();

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -271,7 +271,7 @@ namespace CV19INeedHelp.Gateways.V1
                 _dbContext.SaveChanges();
             }
         }
-        
+
         public void RevertAnnexDeliveryDates(List<DeliveryReportItem> data)
         {
             foreach (var item in data)
@@ -287,6 +287,12 @@ namespace CV19INeedHelp.Gateways.V1
             LambdaLogger.Log($"Searching for an existing delivery batch with date {deliveryDay.Date}");
             var batchSearch = _dbContext.DeliveryBatch.FirstOrDefault(x => x.DeliveryDate == deliveryDay.Date);
             return batchSearch;
+        }
+        
+        public DeliveryBatch GetBatchById(int id)
+        {
+            var batchRecord = _dbContext.DeliveryBatch.Find(id);
+            return batchRecord;
         }
 
         private List<ResidentSupportAnnex> GetData(int limit)

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -262,17 +262,16 @@ namespace CV19INeedHelp.Gateways.V1
         public void DeleteBatch(int id)
         {
             var batchRecord = _dbContext.DeliveryBatch.Find(id);
-            if (batchRecord != null)
-            {
-                var data = _dbContext.DeliveryReportData.Where(x => x.BatchId == batchRecord.Id);
-                _dbContext.DeliveryReportData.RemoveRange(data);
-                _dbContext.SaveChanges();
-                _dbContext.DeliveryBatch.Remove(batchRecord);
-                _dbContext.SaveChanges();
-            }
+            if (batchRecord == null) return;
+            var data = _dbContext.DeliveryReportData.Where(x => x.BatchId == batchRecord.Id);
+            RevertAnnexDeliveryDates(data.ToList());
+            _dbContext.DeliveryReportData.RemoveRange(data);
+            _dbContext.SaveChanges();
+            _dbContext.DeliveryBatch.Remove(batchRecord);
+            _dbContext.SaveChanges();
         }
 
-        public void RevertAnnexDeliveryDates(List<DeliveryReportItem> data)
+        private void RevertAnnexDeliveryDates(List<DeliveryReportItem> data)
         {
             foreach (var item in data)
             {

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -259,6 +259,29 @@ namespace CV19INeedHelp.Gateways.V1
             _dbContext.SaveChanges();
         }
 
+        public void DeleteBatch(int id)
+        {
+            var batchRecord = _dbContext.DeliveryBatch.Find(id);
+            if (batchRecord != null)
+            {
+                var data = _dbContext.DeliveryReportData.Where(x => x.BatchId == batchRecord.Id);
+                _dbContext.DeliveryReportData.RemoveRange(data);
+                _dbContext.SaveChanges();
+                _dbContext.DeliveryBatch.Remove(batchRecord);
+                _dbContext.SaveChanges();
+            }
+        }
+        
+        public void RevertAnnexDeliveryDates(List<DeliveryReportItem> data)
+        {
+            foreach (var item in data)
+            {
+                var annexRecord = _dbContext.ResidentSupportAnnex.Find(item.AnnexId);
+                annexRecord.LastConfirmedFoodDelivery = item.LastConfirmedDeliveryDate;
+            }
+            _dbContext.SaveChanges();
+        }
+
         public DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay)
         {
             LambdaLogger.Log($"Searching for an existing delivery batch with date {deliveryDay.Date}");

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -249,6 +249,16 @@ namespace CV19INeedHelp.Gateways.V1
             return GetData(limit);
         }
 
+        public void UpdateAnnexWithDeliveryDates(List<DeliveryReportItem> data)
+        {
+            foreach (var item in data)
+            {
+                var annexRecord = _dbContext.ResidentSupportAnnex.Find(item.Id);
+                annexRecord.LastConfirmedFoodDelivery = item.DeliveryDate;
+            }
+            _dbContext.SaveChanges();
+        }
+
         private List<ResidentSupportAnnex> GetData(int limit)
         {
             var helper = new UtilityHelper();

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -261,7 +261,8 @@ namespace CV19INeedHelp.Gateways.V1
 
         public DeliveryBatch FindExistingBatchForDate(DateTime deliveryDay)
         {
-            var batchSearch = _dbContext.DeliveryBatch.FirstOrDefault(x => x.DeliveryDate == deliveryDay);
+            LambdaLogger.Log($"Searching for an existing delivery batch with date {deliveryDay.Date}");
+            var batchSearch = _dbContext.DeliveryBatch.FirstOrDefault(x => x.DeliveryDate == deliveryDay.Date);
             return batchSearch;
         }
 

--- a/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
+++ b/cv-19-i-need-help/Gateways/V1/INeedHelpGateway.cs
@@ -253,7 +253,7 @@ namespace CV19INeedHelp.Gateways.V1
         {
             foreach (var item in data)
             {
-                var annexRecord = _dbContext.ResidentSupportAnnex.Find(item.Id);
+                var annexRecord = _dbContext.ResidentSupportAnnex.Find(item.AnnexId);
                 annexRecord.LastConfirmedFoodDelivery = item.DeliveryDate;
             }
             _dbContext.SaveChanges();

--- a/cv-19-i-need-help/Helpers/V1/IDriveHelper.cs
+++ b/cv-19-i-need-help/Helpers/V1/IDriveHelper.cs
@@ -8,5 +8,6 @@ namespace CV19INeedHelp.Helpers.V1
     {
         string CreateSpreadsheet(string name);
         void PopulateSpreadsheet(string sheetId, List<DeliveryReportItem> data);
+        void DeleteSpreadsheet(string spreadsheet);
     }
 }

--- a/cv-19-i-need-help/UseCases/V1/DeliveryScheduleUseCase.cs
+++ b/cv-19-i-need-help/UseCases/V1/DeliveryScheduleUseCase.cs
@@ -1,8 +1,10 @@
 using System.Linq;
+using Amazon.Lambda.Core;
 using CV19INeedHelp.Boundary.V1.Responses;
 using CV19INeedHelp.Gateways.V1;
 using CV19INeedHelp.Helpers.V1;
 using CV19INeedHelp.Models.V1;
+using Newtonsoft.Json;
 
 namespace CV19INeedHelp.UseCases.V1
 {
@@ -65,8 +67,11 @@ namespace CV19INeedHelp.UseCases.V1
             var batch = _iFoodDeliveriesGateway.GetBatchById(id);
             if (batch != null)
             {
+                LambdaLogger.Log($"Executing delete spreadsheet method for {batch.ReportFileId}.");
                 _driveHelper.DeleteSpreadsheet(batch.ReportFileId);
-                _iFoodDeliveriesGateway.DeleteBatch(id);
+                LambdaLogger.Log($"Executing delete batch method for batch {batch.Id}.");
+                _iFoodDeliveriesGateway.DeleteBatch(batch.Id);
+                LambdaLogger.Log($"Batch deletion completed.");
             }
         }
     }

--- a/cv-19-i-need-help/UseCases/V1/DeliveryScheduleUseCase.cs
+++ b/cv-19-i-need-help/UseCases/V1/DeliveryScheduleUseCase.cs
@@ -27,13 +27,7 @@ namespace CV19INeedHelp.UseCases.V1
                 var data = _iFoodDeliveriesGateway.CreateDeliverySchedule(limit, spreadsheet);
                 _driveHelper.PopulateSpreadsheet(spreadsheet, data);
                 var responseDetails = data.FirstOrDefault();
-                // TODO:  Enable this to update the annex with next set of delivery dates.
-                // foreach (var item in data)
-                // {
-                //     var annexPatch = new ResidentSupportAnnexPatch();
-                //     annexPatch.LastConfirmedFoodDelivery = item.DeliveryDate;
-                //     _iFoodDeliveriesGateway.PatchHelpRequest(item.AnnexId, annexPatch);   
-                // }
+                _iFoodDeliveriesGateway.UpdateAnnexWithDeliveryDates(data);
                 return new DeliveryBatch()
                 {
                     DeliveryDate = responseDetails.DeliveryDate,

--- a/cv-19-i-need-help/UseCases/V1/IDeliveryScheduleUseCase.cs
+++ b/cv-19-i-need-help/UseCases/V1/IDeliveryScheduleUseCase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using CV19INeedHelp.Boundary.V1.Responses;
 using CV19INeedHelp.Models.V1;
 
 namespace CV19INeedHelp.UseCases.V1
@@ -6,5 +7,7 @@ namespace CV19INeedHelp.UseCases.V1
     public interface IDeliveryScheduleUseCase
     {
         object CreateDeliverySchedule(int limit, bool confirmed);
+        DeliveryBatchResponse GetDeliveryBatch();
+        void DeleteDeliveryBatch(int id);
     }
 }

--- a/cv-19-i-need-help/serverless.yml
+++ b/cv-19-i-need-help/serverless.yml
@@ -147,6 +147,42 @@ functions:
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: false
+  getDeliveryBatch-v1:
+    handler: CsharpHandlers::CV19INeedHelp.Boundary.V1.Handler::GetDeliveryBatch
+    package:
+      artifact: bin/release/netcoreapp2.1/cv-19-i-need-help.zip
+    events:
+      - http:
+          path: delivery-batch
+          method: get
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+            allowCredentials: false
+  deleteDeliveryBatch-v1:
+    handler: CsharpHandlers::CV19INeedHelp.Boundary.V1.Handler::DeleteDeliveryBatch
+    package:
+      artifact: bin/release/netcoreapp2.1/cv-19-i-need-help.zip
+    events:
+      - http:
+          path: delivery-batch/{id}
+          method: delete
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+            allowCredentials: false
   getFoodDeliveryRequestsForForm-v1:
     handler: CsharpHandlers::CV19INeedHelp.Boundary.V1.Handler::GetFoodDeliveriesRequestForForm
     package:

--- a/cv-19-i-need-help/serverless.yml
+++ b/cv-19-i-need-help/serverless.yml
@@ -125,7 +125,7 @@ functions:
             allowCredentials: false
   generateDeliverySchedule-v1:
     handler: CsharpHandlers::CV19INeedHelp.Boundary.V1.Handler::GenerateDeliverySchedule
-    timeout: 45
+    timeout: 25
     package:
       artifact: bin/release/netcoreapp2.1/cv-19-i-need-help.zip
     events:
@@ -167,6 +167,7 @@ functions:
             allowCredentials: false
   deleteDeliveryBatch-v1:
     handler: CsharpHandlers::CV19INeedHelp.Boundary.V1.Handler::DeleteDeliveryBatch
+    timeout: 25
     package:
       artifact: bin/release/netcoreapp2.1/cv-19-i-need-help.zip
     events:

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -90,13 +90,13 @@ CREATE SEQUENCE public.delivery_report_data_id_seq
     CACHE 1;
 
 --
--- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: delivery_report_data id; Type: DEFAULT; Schema: public; Owner: postgres
 --
     
 ALTER TABLE public.delivery_report_data_id_seq OWNER TO postgres;
 
 --
--- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: delivery_report_data id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
 ALTER SEQUENCE public.delivery_report_data_id_seq OWNED BY public.delivery_report_data.id;
@@ -105,7 +105,7 @@ ALTER SEQUENCE public.delivery_report_data_id_seq OWNED BY public.delivery_repor
 -- Name: delivery_report_data id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY public.delivery_batch ALTER COLUMN id SET DEFAULT nextval('public.delivery_report_data_id_seq'::regclass);
+ALTER TABLE ONLY public.delivery_report_data ALTER COLUMN id SET DEFAULT nextval('public.delivery_report_data_id_seq'::regclass);
 
 -----
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -14,6 +14,102 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.delivery_batch (
+    "id" int4 NOT NULL,
+    "delivery_date" date,
+    "delivery_packages" int4,
+    "report_file_id" varchar,
+    "status" varchar,
+    PRIMARY KEY ("id")
+);
+
+ALTER TABLE public.delivery_batch OWNER TO postgres;
+
+-- Sequence and defined type
+CREATE SEQUENCE public.delivery_batch_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+    
+ALTER TABLE public.delivery_batch_id_seq OWNER TO postgres;
+
+--
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.delivery_batch_id_seq OWNED BY public.delivery_batch.id;
+
+--
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.delivery_batch ALTER COLUMN id SET DEFAULT nextval('public.delivery_batch_id_seq'::regclass);
+
+-----
+--
+-- Name: delivery_report_data id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.delivery_report_data (
+    "id" int4 NOT NULL,
+    "annex_id" int4,
+    "num_of_packages" int4,
+    "full_name" varchar,
+    "contact_telephone_number" varchar,
+    "contact_mobile_number" varchar,
+    "full_address" varchar,
+    "postcode" varchar,
+    "uprn" varchar,
+    "any_food_household_cannot_eat" varchar,
+    "delivery_notes" text,
+    "delivery_date" date,
+    "last_confirmed_delivery_date" date,
+    "batch_id" int4,
+    PRIMARY KEY ("id")
+);
+
+ALTER TABLE public.delivery_report_data OWNER TO postgres;
+
+-- Sequence and defined type
+CREATE SEQUENCE public.delivery_report_data_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+    
+ALTER TABLE public.delivery_report_data_id_seq OWNER TO postgres;
+
+--
+-- Name: delivery_batch id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.delivery_report_data_id_seq OWNED BY public.delivery_report_data.id;
+
+--
+-- Name: delivery_report_data id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.delivery_batch ALTER COLUMN id SET DEFAULT nextval('public.delivery_report_data_id_seq'::regclass);
+
+-----
+
+--
 -- Name: resident_support_annex; Type: TABLE; Schema: public; Owner: postgres
 --
 
@@ -70,7 +166,6 @@ CREATE TABLE public.resident_support_annex (
     delivery_notes text
 );
 
-
 ALTER TABLE public.resident_support_annex OWNER TO postgres;
 
 --
@@ -84,7 +179,6 @@ CREATE SEQUENCE public.resident_support_annex_id_seq
     NO MINVALUE
     NO MAXVALUE
     CACHE 1;
-
 
 ALTER TABLE public.resident_support_annex_id_seq OWNER TO postgres;
 


### PR DESCRIPTION
Added endpoints to regenerate the delivery schedule if required.  This allows the client to:

- delete an existing delivery batch and create a new one
- create a new delivery batch for the next delivery day
- return the batch information for the next delivery day if it already exists